### PR TITLE
Enhance hero overlay UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -149,16 +149,29 @@ function bindTableEvents() {
   );
 }
 
-// Show overlay with large image + full JSON details
+// Show overlay with large image and key details
 function openDetail(id) {
   const h = heroes.find(x=>x.id===id);
   if (!h) return;
   state.selectedId = id; syncURL();
   const c = document.getElementById('detailContent');
   c.innerHTML = `
-    <h2>${h.name} (${h.id})</h2>
+    <h2>${h.name}</h2>
     <img src="${h.images.lg}" />
-    <pre>${JSON.stringify(h, null, 2)}</pre>
+    <p><strong>Full Name:</strong> ${h.biography.fullName || 'Unknown'}</p>
+    <p><strong>Race:</strong> ${h.appearance.race}</p>
+    <p><strong>Gender:</strong> ${h.appearance.gender}</p>
+    <p><strong>Height:</strong> ${h.appearance.height[1]}</p>
+    <p><strong>Weight:</strong> ${h.appearance.weight[1]}</p>
+    <h3>Power Stats</h3>
+    <div class="stats">
+      <div><strong>Intelligence:</strong> ${h.powerstats.intelligence}</div>
+      <div><strong>Strength:</strong> ${h.powerstats.strength}</div>
+      <div><strong>Speed:</strong> ${h.powerstats.speed}</div>
+      <div><strong>Durability:</strong> ${h.powerstats.durability}</div>
+      <div><strong>Power:</strong> ${h.powerstats.power}</div>
+      <div><strong>Combat:</strong> ${h.powerstats.combat}</div>
+    </div>
   `;
   document.getElementById('overlay').style.display = 'flex';
 }

--- a/style.css
+++ b/style.css
@@ -47,6 +47,9 @@ th:hover {
 tbody tr:nth-child(odd) {
   background: rgba(0,0,0,0.05);
 }
+tbody tr {
+  cursor: pointer;
+}
 img.icon {
   width: 32px;
   height: 32px;
@@ -61,6 +64,7 @@ img.icon {
   border: 2px solid #000;
   background: #fff;
   font-family: inherit;
+  cursor: pointer;
 }
 .overlay {
   display: none;
@@ -81,6 +85,22 @@ img.icon {
   position: relative;
   font-size: 0.9rem;
 }
+.overlay .detail h2 {
+  font-family: 'Bangers', cursive;
+  font-size: 2rem;
+  margin-top: 0;
+}
+.overlay .detail p {
+  margin: 0.25rem 0;
+}
+.overlay .detail .stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+.overlay .detail .stats div {
+  flex: 1 1 120px;
+}
 .overlay .close {
   position: absolute;
   top: 0.5rem; right: 0.5rem;
@@ -89,7 +109,7 @@ img.icon {
   font-weight: bold;
 }
 .detail img {
-  max-width: 200px;
+  max-width: 300px;
   float: right;
   margin: 0 0 1rem 1rem;
 }


### PR DESCRIPTION
## Summary
- make clickable rows and buttons show pointer cursor
- display a cleaner hero detail overlay with a big image and key stats
- style overlay headings and power stats section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e05e201008324abbd4ae9186c263f