### PR TITLE
Add card layout and filter menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,26 +12,30 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Villain Dashboard</h1>
-
-  <!-- Search controls -->
-  <div class="controls">
-    <input id="search" placeholder="Search..." />
-    <select id="searchField"></select>
-    <select id="pageSize">
-      <option value="10">10</option>
-      <option value="20" selected>20</option>
-      <option value="50">50</option>
-      <option value="100">100</option>
-      <option value="all">All</option>
-    </select>
+  <button id="burgerBtn" aria-label="menu">☰</button>
+  <div id="menu" class="menu">
+    <div class="controls">
+      <input id="search" placeholder="Search..." />
+      <select id="searchField"></select>
+      <select id="sortField"></select>
+      <select id="sortDir">
+        <option value="asc">Asc</option>
+        <option value="desc">Desc</option>
+      </select>
+      <select id="pageSize">
+        <option value="10">10</option>
+        <option value="20" selected>20</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+        <option value="all">All</option>
+      </select>
+    </div>
   </div>
 
-  <!-- Results table populated by app.js -->
-  <table>
-    <thead><tr id="tableHead"></tr></thead>
-    <tbody id="tableBody"></tbody>
-  </table>
+  <h1>Villain Dashboard</h1>
+
+  <!-- Cards populated by app.js -->
+  <div id="cards" class="cards"></div>
 
   <!-- Pagination buttons go here -->
   <div class="pagination" id="pagination"></div>

--- a/style.css
+++ b/style.css
@@ -14,6 +14,51 @@ h1 {
   color: #d32f2f;
   text-shadow: 2px 2px #000;
 }
+#burgerBtn {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  background: #ffeb3b;
+  border: 4px solid #000;
+  font-size: 1.5rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  z-index: 1000;
+}
+#menu {
+  display: none;
+  position: fixed;
+  top: 2.5rem;
+  left: 0.5rem;
+  background: #fff;
+  border: 4px solid #000;
+  border-radius: 1rem;
+  padding: 1rem;
+  z-index: 999;
+}
+#menu.show {
+  display: block;
+}
+#menu::after {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  bottom: -20px;
+  width: 0;
+  height: 0;
+  border: 10px solid transparent;
+  border-top-color: #000;
+}
+#menu::before {
+  content: '';
+  position: absolute;
+  left: 1.1rem;
+  bottom: -18px;
+  width: 0;
+  height: 0;
+  border: 10px solid transparent;
+  border-top-color: #fff;
+}
 .controls {
   display: flex;
   flex-wrap: wrap;
@@ -27,32 +72,31 @@ h1 {
   font-size: 1rem;
   font-family: inherit;
 }
-table {
+
+/* card layout */
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+.card {
+  width: 280px;
+  background: #fff;
+  border: 4px solid #000;
+  padding: 1rem;
+}
+.card img {
   width: 100%;
-  border-collapse: collapse;
-  margin-bottom: 1rem;
+  height: auto;
 }
-th, td {
-  border: 2px solid #000;
-  padding: 0.5rem;
-  text-align: left;
+.card h2 {
+  font-family: 'Bangers', cursive;
+  margin: 0.5rem 0;
+  font-size: 1.5rem;
 }
-th {
-  background: #ffeb3b;
-  cursor: pointer;
-}
-th:hover {
-  background: #fff176;
-}
-tbody tr:nth-child(odd) {
-  background: rgba(0,0,0,0.05);
-}
-tbody tr {
-  cursor: pointer;
-}
-img.icon {
-  width: 32px;
-  height: 32px;
+.card h3 {
+  margin: 0.5rem 0 0.25rem;
 }
 .pagination {
   text-align: center;


### PR DESCRIPTION
## Summary
- use burger button to reveal filter/sort controls
- replace table layout with responsive hero cards
- implement comic-style pop-out menu
- allow sorting by selectable field and direction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e3c92971c83248ed7f2c42da80273