### PR TITLE
Add top-right view toggle button

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,13 @@ const state = {
   viewMode: 'cards'
 };
 
+// Update the toggle button text based on current view
+function updateViewButton() {
+  const btn = document.getElementById('viewToggleBtn');
+  if (btn)
+    btn.textContent = state.viewMode === 'cards' ? 'Cards' : 'List';
+}
+
 // Which fields show in table (use metric units by default)
 const fields = [
   { key: 'images.xs',            label: 'Icon' },
@@ -269,6 +276,7 @@ async function init() {
   renderControls();
   document.getElementById('search').value = state.searchTerm;
   document.getElementById('viewMode').value = state.viewMode;
+  updateViewButton();
   document.getElementById('search').addEventListener('input', e => {
     state.searchTerm = e.target.value;
     state.page = 1; syncURL(); renderCards();
@@ -292,9 +300,16 @@ async function init() {
   document.getElementById('viewMode').addEventListener('change', e => {
     state.viewMode = e.target.value;
     state.page = 1; syncURL(); renderCards();
+    updateViewButton();
   });
   document.getElementById('burgerBtn').addEventListener('click', () => {
     document.getElementById('menu').classList.toggle('show');
+  });
+  document.getElementById('viewToggleBtn').addEventListener('click', () => {
+    state.viewMode = state.viewMode === 'cards' ? 'list' : 'cards';
+    document.getElementById('viewMode').value = state.viewMode;
+    state.page = 1; syncURL(); renderCards();
+    updateViewButton();
   });
   renderCards();
   if (state.selectedId) openDetail(state.selectedId);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <button id="burgerBtn" aria-label="menu">☰</button>
+  <button id="viewToggleBtn" aria-label="toggle view"></button>
   <div id="menu" class="menu">
     <div class="controls">
       <input id="search" placeholder="Search..." />

--- a/style.css
+++ b/style.css
@@ -25,6 +25,17 @@ h1 {
   cursor: pointer;
   z-index: 1000;
 }
+#viewToggleBtn {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #ffeb3b;
+  border: 4px solid #000;
+  font-size: 1rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  z-index: 1000;
+}
 #menu {
   display: none;
   position: fixed;


### PR DESCRIPTION
## Summary
- add a new `viewToggleBtn` on the page
- style the button so it sits on the top-right of the viewport
- implement JS logic to sync the button with the current view and toggle between card and list views

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f3bfa2ca083248267c78d7963b4b7