### PR TITLE
Improve list view sorting

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,14 +22,17 @@ function updateViewButton() {
 }
 
 // Which fields show in table (use metric units by default)
+// Reduced set of fields for the list view
+// Only the most commonly useful bits are shown to avoid clutter
 const fields = [
   { key: 'images.xs', label: 'Icon' },
   { key: 'name', label: 'Name' },
-  { key: 'powerstats', label: 'Powerstats' },
-  { key: 'appearance', label: 'Appearance' },
-  { key: 'biography', label: 'Biography' },
-  { key: 'work', label: 'Work' },
-  { key: 'connections', label: 'Connections' }
+  { key: 'appearance.race', label: 'Race' },
+  { key: 'appearance.gender', label: 'Gender' },
+  { key: 'biography.alignment', label: 'Alignment' },
+  { key: 'powerstats.intelligence', label: 'Intelligence' },
+  { key: 'powerstats.strength', label: 'Strength' },
+  { key: 'powerstats.power', label: 'Power' }
 ];
 
 // Helper to safely drill into nested props (with array index)
@@ -73,6 +76,8 @@ function renderControls() {
 
 // Render card list with filtering, sorting and pagination
 function renderCards() {
+  // keep dropdown values in sync with current state
+  renderControls();
   let data = heroes.slice();
 
   // Filter by search term in chosen field
@@ -122,7 +127,14 @@ function renderCards() {
 
   const cardsEl = document.getElementById('cards');
   if (state.viewMode === 'list') {
-    const header = fields.map(f => `<th>${f.label}</th>`).join('');
+    // Build sortable header - clicking toggles sort direction
+    const header = fields.map(f => {
+      const indicator = state.sortField === f.key
+        ? (state.sortDir === 'asc' ? ' \u25B2' : ' \u25BC')
+        : '';
+      return `<th data-field="${f.key}">${f.label}${indicator}</th>`;
+    }).join('');
+
     const rows = pageItems.map(h => {
       const cells = fields.map(f => {
         const val = getNested(h, f.key);
@@ -133,7 +145,8 @@ function renderCards() {
       }).join('');
       return `<tr data-id="${h.id}">${cells}</tr>`;
     }).join('');
-    cardsEl.innerHTML = `<table class="list-table"><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table>`;
+    cardsEl.innerHTML =
+      `<table class="list-table"><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table>`;
   } else {
     cardsEl.innerHTML = pageItems.map(h => `
       <div class="card" data-id="${h.id}">
@@ -193,6 +206,22 @@ function bindCardEvents() {
   document.querySelectorAll('.card, tr[data-id]').forEach(el =>
     el.onclick = () => openDetail(+el.dataset.id)
   );
+
+  // Enable sorting by clicking on table headers
+  document.querySelectorAll('th[data-field]').forEach(th => {
+    th.onclick = () => {
+      const field = th.dataset.field;
+      if (state.sortField === field) {
+        state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        state.sortField = field;
+        state.sortDir = 'asc';
+      }
+      state.page = 1;
+      syncURL();
+      renderCards();
+    };
+  });
 }
 
 // Show overlay with a larger image and selected hero details


### PR DESCRIPTION
## Summary
- simplify the columns shown in list mode
- add interactive sorting by clicking table headers

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f4009588083249efc6b1cb4750715