### PR TITLE
Add sortable list view with alignment filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,12 @@
         <option value="asc">Asc</option>
         <option value="desc">Desc</option>
       </select>
+      <select id="alignmentFilter">
+        <option value="">All Alignments</option>
+        <option value="good">Good</option>
+        <option value="bad">Bad</option>
+        <option value="neutral">Neutral</option>
+      </select>
       <select id="pageSize">
         <option value="10">10</option>
         <option value="20" selected>20</option>
@@ -31,8 +37,8 @@
         <option value="all">All</option>
       </select>
       <select id="viewMode">
-        <option value="cards" selected>Cards</option>
-        <option value="list">List</option>
+        <option value="cards">Cards</option>
+        <option value="list" selected>List</option>
       </select>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -98,8 +98,12 @@ h1 {
   padding: 1rem;
 }
 .card img {
-  width: 100%;
-  height: auto;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto;
 }
 .card h2 {
   font-family: 'Bangers', cursive;
@@ -181,8 +185,16 @@ h1 {
 }
 .list-table th {
   background: #ffeb3b;
+  cursor: pointer;
 }
 .list-table tr:hover {
   background: #f1f1f1;
   cursor: pointer;
+}
+
+.list-table img {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- default to list view instead of cards
- show larger circular images
- add alignment filter selector
- provide sortable table columns for detailed stats
- allow column header clicks to sort

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_687f42b9dcfc8324945943c4b264f7a6