### PR TITLE
Add reset filters button and expand biography

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,12 +19,29 @@ const state = {
   eyeColor: '',
   hairColor: ''
 };
+const defaultState = { ...state };
 
 // Update the toggle button text based on current view
 function updateViewButton() {
   const btn = document.getElementById('viewToggleBtn');
   if (btn)
     btn.textContent = state.viewMode === 'cards' ? 'Cards' : 'List';
+}
+
+// Reset all filters and controls to their default values
+function resetFilters() {
+  Object.assign(state, { ...defaultState });
+  document.getElementById('search').value = '';
+  document.getElementById('searchField').value = state.searchField;
+  document.getElementById('pageSize').value = state.pageSize;
+  document.getElementById('sortField').value = state.sortField;
+  document.getElementById('sortDir').value = state.sortDir;
+  document.getElementById('alignmentFilter').value = state.alignment;
+  document.getElementById('viewMode').value = state.viewMode;
+  updateViewButton();
+  state.page = 1;
+  syncURL();
+  renderCards();
 }
 
 // Which fields are available for searching/sorting
@@ -248,8 +265,11 @@ function renderCards() {
           <li>Hair: ${h.appearance.hairColor}</li>
         </ul>
         <h3>Biography</h3>
-        <p>Place of Birth: ${h.biography.placeOfBirth}</p>
-        <p>Alignment: ${h.biography.alignment}</p>
+        <ul>
+          <li>Alignment: ${h.biography.alignment}</li>
+          <li>Occupation: ${h.work.occupation}</li>
+          <li>Place of Birth: ${h.biography.placeOfBirth}</li>
+        </ul>
       </div>
     `).join('');
   }
@@ -335,6 +355,12 @@ function openDetail(id) {
       <div><strong>Power:</strong> ${h.powerstats.power}</div>
       <div><strong>Combat:</strong> ${h.powerstats.combat}</div>
     </div>
+    <h3>Biography</h3>
+    <ul>
+      <li>Alignment: ${h.biography.alignment}</li>
+      <li>Occupation: ${h.work.occupation}</li>
+      <li>Place of Birth: ${h.biography.placeOfBirth}</li>
+    </ul>
   `;
   document.getElementById('overlay').style.display = 'flex';
 }
@@ -520,6 +546,7 @@ async function init() {
     state.page = 1; syncURL(); renderCards();
     updateViewButton();
   });
+  document.getElementById('resetBtn').addEventListener('click', resetFilters);
   document.getElementById('burgerBtn').addEventListener('click', () => {
     document.getElementById('menu').classList.toggle('show');
   });

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <option value="cards">Cards</option>
         <option value="list" selected>List</option>
       </select>
+      <button id="resetBtn">Default</button>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -83,6 +83,10 @@ h1 {
   font-size: 1rem;
   font-family: inherit;
 }
+.controls button {
+  cursor: pointer;
+  background: #ffeb3b;
+}
 
 /* card layout */
 .cards {


### PR DESCRIPTION
## Summary
- add a **Default** button to clear all search filters
- style the new button
- show alignment and occupation in card and detail biography sections

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f4ce136908324aca1e7a75229a219