### PR TITLE
Add dynamic search controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,13 @@
 <body>
   <button id="burgerBtn" aria-label="menu">☰</button>
   <button id="viewToggleBtn" aria-label="toggle view"></button>
+  <div id="searchBar" class="search-bar">
+    <input id="search" placeholder="Search..." />
+    <select id="searchGroup"></select>
+    <select id="searchField"></select>
+  </div>
   <div id="menu" class="menu">
     <div class="controls">
-      <input id="search" placeholder="Search..." />
-      <select id="searchField"></select>
       <select id="sortField"></select>
       <select id="sortDir">
         <option value="asc">Asc</option>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,23 @@ h1 {
   cursor: pointer;
   z-index: 1000;
 }
+
+#searchBar {
+  position: fixed;
+  top: 0.5rem;
+  left: 3rem;
+  display: flex;
+  gap: 0.25rem;
+  z-index: 1000;
+}
+
+#searchBar > * {
+  padding: 0.25rem;
+  border: 3px solid #000;
+  background: #fff;
+  font-size: 1rem;
+  font-family: inherit;
+}
 #menu {
   display: none;
   position: fixed;


### PR DESCRIPTION
## Summary
- add fixed search bar with two drop downs
- populate second drop down based on the first selection
- wire new state and listeners in `app.js`
- style the search bar so it sits in the top left

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f6ff84a8c8324abdaa8adc04367ac