### PR TITLE
Include heroes without alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -596,10 +596,8 @@ async function init() {
     "https://rawcdn.githack.com/akabab/superhero-api/0.2.0/api/all.json"
   );
   const rawHeroes = await res.json();
-  heroes = rawHeroes.filter(h => {
-    const a = h.biography?.alignment?.toLowerCase();
-    return ['good', 'bad', 'neutral'].includes(a);
-  });
+  // Include every hero from the dataset, even if alignment is missing
+  heroes = rawHeroes;
   computeAppearanceOptions();
   loadFromURL();
   renderControls();


### PR DESCRIPTION
## Summary
- load all heroes from the API instead of filtering by alignment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f771f79008324a31e46861c5aa4a3