### PR TITLE
Remove menu and add page size dropdown to search bar

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,15 +169,8 @@ function renderControls() {
 
   renderSearchFieldOptions();
 
-  const sortF = document.getElementById('sortField');
-  sortF.innerHTML = allFields.map(f =>
-    `<option value="${f.key}">${f.label}</option>`
-  ).join('');
-  sortF.value = state.sortField;
-
-  document.getElementById('sortDir').value = state.sortDir;
-  document.getElementById('alignmentFilter').value = state.alignment;
-  document.getElementById('viewMode').value = state.viewMode;
+  const pageSel = document.getElementById('pageSize');
+  if (pageSel) pageSel.value = state.pageSize;
 }
 
 function renderSearchFieldOptions() {
@@ -379,8 +372,6 @@ function bindCardEvents() {
         state.sortField = key;
         state.sortDir = 'asc';
       }
-      document.getElementById('sortField').value = state.sortField;
-      document.getElementById('sortDir').value = state.sortDir;
       state.page = 1;
       syncURL();
       renderCards();
@@ -443,8 +434,6 @@ document.getElementById('sortConfirm').onclick = () => {
   const order = document.getElementById('statOrder').value;
   state.sortField = `powerstats.${stat}`;
   state.sortDir = order;
-  document.getElementById('sortField').value = state.sortField;
-  document.getElementById('sortDir').value = state.sortDir;
   document.getElementById('sortModal').style.display = 'none';
   state.page = 1;
   syncURL();
@@ -499,8 +488,6 @@ document.getElementById('appearanceConfirm').onclick = () => {
   const sf = document.getElementById('appearanceSortField').value;
   state.sortField = sf ? `appearance.${sf}[1]` : state.sortField;
   state.sortDir = document.getElementById('appearanceSortDir').value;
-  document.getElementById('sortField').value = state.sortField;
-  document.getElementById('sortDir').value = state.sortDir;
   document.getElementById('appearanceModal').style.display = 'none';
   state.page = 1;
   syncURL();
@@ -525,7 +512,6 @@ document.getElementById('biographyCancel').onclick = () => {
 };
 document.getElementById('biographyConfirm').onclick = () => {
   state.alignment = document.getElementById('alignmentSelect').value;
-  document.getElementById("alignmentFilter").value = state.alignment;
   document.getElementById("biographyModal").style.display = "none";
   state.page = 1;
   syncURL();
@@ -602,8 +588,6 @@ async function init() {
   loadFromURL();
   renderControls();
   document.getElementById('search').value = state.searchTerm;
-  document.getElementById('viewMode').value = state.viewMode;
-  document.getElementById('alignmentFilter').value = state.alignment;
   updateViewButton();
   document.getElementById('search').addEventListener('input', e => {
     state.searchTerm = e.target.value;
@@ -622,29 +606,9 @@ async function init() {
     state.pageSize = e.target.value==='all'?'all':+e.target.value;
     state.page = 1; syncURL(); renderCards();
   });
-  document.getElementById('sortField').addEventListener('change', e => {
-    state.sortField = e.target.value;
-    state.page = 1; syncURL(); renderCards();
-  });
-  document.getElementById('sortDir').addEventListener('change', e => {
-    state.sortDir = e.target.value;
-    state.page = 1; syncURL(); renderCards();
-  });
-  document.getElementById('alignmentFilter').addEventListener('change', e => {
-    state.alignment = e.target.value;
-    state.page = 1; syncURL(); renderCards();
-  });
-  document.getElementById('viewMode').addEventListener('change', e => {
-    state.viewMode = e.target.value;
-    state.page = 1; syncURL(); renderCards();
-    updateViewButton();
-  });
-  document.getElementById('burgerBtn').addEventListener('click', () => {
-    document.getElementById('menu').classList.toggle('show');
-  });
+  // removed menu-based controls; page size selector is now in the search bar
   document.getElementById('viewToggleBtn').addEventListener('click', () => {
     state.viewMode = state.viewMode === 'cards' ? 'list' : 'cards';
-    document.getElementById('viewMode').value = state.viewMode;
     state.page = 1; syncURL(); renderCards();
     updateViewButton();
   });

--- a/index.html
+++ b/index.html
@@ -12,38 +12,18 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <button id="burgerBtn" aria-label="menu">☰</button>
   <button id="viewToggleBtn" aria-label="toggle view"></button>
   <div id="searchBar" class="search-bar">
     <input id="search" placeholder="Search..." />
     <select id="searchGroup"></select>
     <select id="searchField"></select>
-  </div>
-  <div id="menu" class="menu">
-    <div class="controls">
-      <select id="sortField"></select>
-      <select id="sortDir">
-        <option value="asc">Asc</option>
-        <option value="desc">Desc</option>
-      </select>
-      <select id="alignmentFilter">
-        <option value="">All Alignments</option>
-        <option value="good">Good</option>
-        <option value="bad">Bad</option>
-        <option value="neutral">Neutral</option>
-      </select>
-      <select id="pageSize">
-        <option value="10">10</option>
-        <option value="20" selected>20</option>
-        <option value="50">50</option>
-        <option value="100">100</option>
-        <option value="all">All</option>
-      </select>
-      <select id="viewMode">
-        <option value="cards">Cards</option>
-        <option value="list" selected>List</option>
-      </select>
-    </div>
+    <select id="pageSize">
+      <option value="10">10</option>
+      <option value="20" selected>20</option>
+      <option value="50">50</option>
+      <option value="100">100</option>
+      <option value="all">All</option>
+    </select>
   </div>
 
   <h1>Villain Dashboard</h1>

--- a/style.css
+++ b/style.css
@@ -14,17 +14,6 @@ h1 {
   color: #d32f2f;
   text-shadow: 2px 2px #000;
 }
-#burgerBtn {
-  position: fixed;
-  top: 0.5rem;
-  left: 0.5rem;
-  background: #ffeb3b;
-  border: 4px solid #000;
-  font-size: 1.5rem;
-  padding: 0.25rem 0.5rem;
-  cursor: pointer;
-  z-index: 1000;
-}
 #viewToggleBtn {
   position: fixed;
   top: 0.5rem;
@@ -40,7 +29,7 @@ h1 {
 #searchBar {
   position: fixed;
   top: 0.5rem;
-  left: 3rem;
+  left: 0.5rem;
   display: flex;
   gap: 0.25rem;
   z-index: 1000;
@@ -48,53 +37,6 @@ h1 {
 
 #searchBar > * {
   padding: 0.25rem;
-  border: 3px solid #000;
-  background: #fff;
-  font-size: 1rem;
-  font-family: inherit;
-}
-#menu {
-  display: none;
-  position: fixed;
-  top: 2.5rem;
-  left: 0.5rem;
-  background: #fff;
-  border: 4px solid #000;
-  border-radius: 1rem;
-  padding: 1rem;
-  z-index: 999;
-}
-#menu.show {
-  display: block;
-}
-#menu::after {
-  content: '';
-  position: absolute;
-  left: 1rem;
-  bottom: -20px;
-  width: 0;
-  height: 0;
-  border: 10px solid transparent;
-  border-top-color: #000;
-}
-#menu::before {
-  content: '';
-  position: absolute;
-  left: 1.1rem;
-  bottom: -18px;
-  width: 0;
-  height: 0;
-  border: 10px solid transparent;
-  border-top-color: #fff;
-}
-.controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-.controls > * {
-  padding: 0.5rem;
   border: 3px solid #000;
   background: #fff;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- remove burger menu and associated controls
- add page size selector directly in the search bar
- simplify JS to reflect new layout and remove unused menu event handlers
- adjust styles for search bar position and remove menu/burger styles

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f7dd569508324ae81bf037795ec03