### PR TITLE
Add default button to search bar

### DIFF
--- a/app.js
+++ b/app.js
@@ -606,6 +606,9 @@ async function init() {
     state.pageSize = e.target.value==='all'?'all':+e.target.value;
     state.page = 1; syncURL(); renderCards();
   });
+  document.getElementById('searchDefault').addEventListener('click', () => {
+    resetFilters();
+  });
   // removed menu-based controls; page size selector is now in the search bar
   document.getElementById('viewToggleBtn').addEventListener('click', () => {
     state.viewMode = state.viewMode === 'cards' ? 'list' : 'cards';

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <option value="100">100</option>
       <option value="all">All</option>
     </select>
+    <button id="searchDefault">Default</button>
   </div>
 
   <h1>Villain Dashboard</h1>


### PR DESCRIPTION
## Summary
- add `searchDefault` button to search bar
- hook up button to `resetFilters()` to restore defaults

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_687f822f62448324a963fd9edce28e67